### PR TITLE
add "@todo" attribute for partials and new aggregate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+# 0.2.10-beta.2 (2015-12-18)
+
+## Features
+### docs
+
+* add "@todo" attribute for partials and new aggregate
+* -- put a "@todo" inside any "@ngdoc" comment block
+* -- create a standalone "documentation comment block" anywhere containing just "@ngdoc @todo ..."
+* -- produces a new "To Do" section displayed last on any associated partial page
+* -- produces an aggregate page where all "@todo" items will be displayed in one list at "/docs/index.html#/todo" URL. Enabled by updating your "Gruntfile.js" as follows:
+```
+    ngdocs: {
+        api: {
+            options: {
+                generatePartialsTodoIndex: true
+        // ...        
+        todo: {
+            api: false,
+            options: {
+                doNotGenerateStandardIndexHtml: true
+            },
+            src: [],
+            title: 'To Do'
+        }
+    }
+```
+
+
 # 0.2.10-beta.1 (2015-12-10)
 
 ## Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-ngdocs",
-  "version": "0.2.10-beta.1",
+  "version": "0.2.10-beta.2",
   "description": "grunt plugin for angularjs documentation",
   "main": "tasks",
   "repository": {

--- a/src/reader.js
+++ b/src/reader.js
@@ -29,12 +29,17 @@ function processJsFile(content, file, section, options) {
 
   lines.forEach(function(line, lineNumber){
     lineNumber++;
+    line = line.replace(/[\n\r]*/gm, '');
     // is the comment starting?
     if (!inDoc && (match = line.match(/^\s*\/\*\*\s*(.*)$/))) {
       line = match[1];
       inDoc = true;
       text = [];
       startingLine = lineNumber;
+    }
+    // is the comment add text
+    if (inDoc){
+      text.push(line.replace(/\s*\*\//, '').replace(/^\s*\*\s?/, ''));
     }
     // are we done?
     if (inDoc && line.match(/\*\//)) {
@@ -46,10 +51,6 @@ function processJsFile(content, file, section, options) {
       }
       doc = null;
       inDoc = false;
-    }
-    // is the comment add text
-    if (inDoc){
-      text.push(line.replace(/^\s*\*\s?/, ''));
     }
   });
   return docs;


### PR DESCRIPTION
- -- put a "@todo" inside any "@ngdoc" comment block
- -- create a standalone "documentation comment block" anywhere
  containing just "@ngdoc @todo ..."
- -- produces a new "To Do" section displayed last on any associated
  partial page
- -- produces an aggregate page where all "@todo" items will be
  displayed in one list at "/docs/index.html#/todo" URL. Enabled by
  updating your "Gruntfile.js" as follows:

```
ngdocs: {
    api: {
        options: {
            generatePartialsTodoIndex: true
    // ...
    todo: {
        api: false,
        options: {
            doNotGenerateStandardIndexHtml: true
        },
        src: [],
        title: 'To Do'
    }
}
```
